### PR TITLE
Fix field reactivity

### DIFF
--- a/resources/js/components/form-panel-custom.vue
+++ b/resources/js/components/form-panel-custom.vue
@@ -17,7 +17,7 @@
         }"
                 v-for="(field, index) in panel.fields"
                 :key="index"
-                v-if="getVisibleComponent(field)"
+                v-show="getVisibleComponent(field)"
                 :is="`${mode}-${field.component}`"
                 :errors="validationErrors"
                 :resource-id="resourceId"


### PR DESCRIPTION
Reactivity is lost when having fields depending on other fields having dependencies.

The reason behind it is the use of `v-if` when looping through the components. Replacing it with `v-show` will ensure vuejs properly watches and reacts to changes in previously hidden fields.

Example:

```
Select::make(__('Type'), 'type')
    ->options([]),

Select::make(__('Model'), 'model')
    ->options([])
    ->if(['type'], fn($value) => $value['type'] === 'value'),

// this won't be rendered even if the condition passes
Select::make(__('Depending on model'), 'depending_on_model')
    ->options([])
    ->if(['model'], fn($value) => $value['model'] === 'value'),
```